### PR TITLE
merge blueprintjs 3.6.1 changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "packages/*"
   ],
   "scripts": {
+    "prepare": "npm run compile && npm run dist",
     "bundle": "lerna run --parallel bundle",
     "compile": "lerna run compile",
     "clean": "lerna run --parallel clean",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@blueprintjs/core",
+  "name": "@nautiluslabs/blueprint-core",
   "version": "3.6.1",
   "description": "Core styles & components",
   "main": "lib/cjs/index.js",

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -16,88 +16,11 @@ import { IOverlayLifecycleProps } from "../overlay/overlay";
 import { Popover } from "../popover/popover";
 import { PopperModifiers } from "../popover/popoverSharedProps";
 
+export { ControlledContextMenu } from "./controlledContextMenu";
+
 export interface IOffset {
     left: number;
     top: number;
-}
-
-export interface IContextMenuProps extends IOverlayLifecycleProps {
-    menu: JSX.Element;
-    usePortal?: boolean;
-    onClose?: () => void;
-    isDarkTheme?: boolean;
-    isOpen?: boolean;
-    offset?: IOffset;
-}
-
-/* istanbul ignore next */
-export class ControlledContextMenu extends AbstractPureComponent<IContextMenuProps, {}> {
-    portalElement: HTMLDivElement;
-
-    constructor(props: IContextMenuProps) {
-        super(props);
-
-        this.portalElement = document.createElement("div");
-        this.portalElement.classList.add(Classes.CONTEXT_MENU);
-        document.body.appendChild(this.portalElement);
-    }
-
-    componentWillUnmount() {
-        this.portalElement.remove();
-    }
-
-    public render() {
-        // prevent right-clicking in a context menu
-        const content = <div onContextMenu={this.cancelContextMenu}>{this.props.menu}</div>;
-        const popoverClassName = classNames({ [Classes.DARK]: this.props.isDarkTheme });
-
-        // HACKHACK: workaround until we have access to Popper#scheduleUpdate().
-        // https://github.com/palantir/blueprint/issues/692
-        // Generate key based on offset so a new Popover instance is created
-        // when offset changes, to force recomputing position.
-        const key = this.props.offset == null ? "" : `${this.props.offset.left}x${this.props.offset.top}`;
-
-        // wrap the popover in a positioned div to make sure it is properly
-        // offset on the screen.
-
-        return ReactDOM.createPortal(
-            <div className={Classes.CONTEXT_MENU_POPOVER_TARGET} style={this.props.offset}>
-                <Popover
-                    {...this.props}
-                    backdropProps={{ onContextMenu: this.handleBackdropContextMenu }}
-                    content={content}
-                    enforceFocus={false}
-                    key={key}
-                    hasBackdrop={true}
-                    isOpen={this.props.isOpen}
-                    minimal={true}
-                    modifiers={POPPER_MODIFIERS}
-                    position={Position.RIGHT_TOP}
-                    popoverClassName={popoverClassName}
-                    target={<div />}
-                    transitionDuration={TRANSITION_DURATION}
-                />
-            </div>,
-            this.portalElement
-        );
-    }
-
-    private cancelContextMenu = (e: React.SyntheticEvent<HTMLDivElement>) => e.preventDefault();
-
-    private handleBackdropContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {
-        // React function to remove from the event pool, useful when using a event within a callback
-        e.persist();
-        e.preventDefault();
-        // wait for backdrop to disappear so we can find the "real" element at event coordinates.
-        // timeout duration is equivalent to transition duration so we know it's animated out.
-        this.setTimeout(() => {
-            // retrigger context menu event at the element beneath the backdrop.
-            // if it has a `contextmenu` event handler then it'll be invoked.
-            // if it doesn't, no native menu will show (at least on OSX) :(
-            const newTarget = document.elementFromPoint(e.clientX, e.clientY);
-            newTarget.dispatchEvent(new MouseEvent("contextmenu", e));
-        }, TRANSITION_DURATION);
-    };
 }
 
 interface IContextMenuState {
@@ -108,10 +31,10 @@ interface IContextMenuState {
     onClose?: () => void;
 }
 
-const POPPER_MODIFIERS: PopperModifiers = {
-    preventOverflow: { boundariesElement: "viewport" }
+export const POPPER_MODIFIERS: PopperModifiers = {
+    preventOverflow: { boundariesElement: "viewport" },
 };
-const TRANSITION_DURATION = 100;
+export const TRANSITION_DURATION = 100;
 
 /* istanbul ignore next */
 class ContextMenu extends AbstractPureComponent<IOverlayLifecycleProps, IContextMenuState> {
@@ -119,7 +42,7 @@ class ContextMenu extends AbstractPureComponent<IOverlayLifecycleProps, IContext
         isDarkTheme: false,
         isOpen: false,
         menu: null,
-        offset: null
+        offset: null,
     };
 
     public render() {

--- a/packages/core/src/components/context-menu/contextMenu.tsx
+++ b/packages/core/src/components/context-menu/contextMenu.tsx
@@ -21,6 +21,85 @@ export interface IOffset {
     top: number;
 }
 
+export interface IContextMenuProps extends IOverlayLifecycleProps {
+    menu: JSX.Element;
+    usePortal?: boolean;
+    onClose?: () => void;
+    isDarkTheme?: boolean;
+    isOpen?: boolean;
+    offset?: IOffset;
+}
+
+/* istanbul ignore next */
+export class ControlledContextMenu extends AbstractPureComponent<IContextMenuProps, {}> {
+    portalElement: HTMLDivElement;
+
+    constructor(props: IContextMenuProps) {
+        super(props);
+
+        this.portalElement = document.createElement("div");
+        this.portalElement.classList.add(Classes.CONTEXT_MENU);
+        document.body.appendChild(this.portalElement);
+    }
+
+    componentWillUnmount() {
+        this.portalElement.remove();
+    }
+
+    public render() {
+        // prevent right-clicking in a context menu
+        const content = <div onContextMenu={this.cancelContextMenu}>{this.props.menu}</div>;
+        const popoverClassName = classNames({ [Classes.DARK]: this.props.isDarkTheme });
+
+        // HACKHACK: workaround until we have access to Popper#scheduleUpdate().
+        // https://github.com/palantir/blueprint/issues/692
+        // Generate key based on offset so a new Popover instance is created
+        // when offset changes, to force recomputing position.
+        const key = this.props.offset == null ? "" : `${this.props.offset.left}x${this.props.offset.top}`;
+
+        // wrap the popover in a positioned div to make sure it is properly
+        // offset on the screen.
+
+        return ReactDOM.createPortal(
+            <div className={Classes.CONTEXT_MENU_POPOVER_TARGET} style={this.props.offset}>
+                <Popover
+                    {...this.props}
+                    backdropProps={{ onContextMenu: this.handleBackdropContextMenu }}
+                    content={content}
+                    enforceFocus={false}
+                    key={key}
+                    hasBackdrop={true}
+                    isOpen={this.props.isOpen}
+                    minimal={true}
+                    modifiers={POPPER_MODIFIERS}
+                    position={Position.RIGHT_TOP}
+                    popoverClassName={popoverClassName}
+                    target={<div />}
+                    transitionDuration={TRANSITION_DURATION}
+                />
+            </div>,
+            this.portalElement
+        );
+    }
+
+    private cancelContextMenu = (e: React.SyntheticEvent<HTMLDivElement>) => e.preventDefault();
+
+    private handleBackdropContextMenu = (e: React.MouseEvent<HTMLDivElement>) => {
+        // React function to remove from the event pool, useful when using a event within a callback
+        e.persist();
+        e.preventDefault();
+        // wait for backdrop to disappear so we can find the "real" element at event coordinates.
+        // timeout duration is equivalent to transition duration so we know it's animated out.
+        this.setTimeout(() => {
+            // retrigger context menu event at the element beneath the backdrop.
+            // if it has a `contextmenu` event handler then it'll be invoked.
+            // if it doesn't, no native menu will show (at least on OSX) :(
+            const newTarget = document.elementFromPoint(e.clientX, e.clientY);
+            newTarget.dispatchEvent(new MouseEvent("contextmenu", e));
+        }, TRANSITION_DURATION);
+    };
+}
+
 interface IContextMenuState {
     isOpen: boolean;
     isDarkTheme: boolean;
@@ -30,7 +109,7 @@ interface IContextMenuState {
 }
 
 const POPPER_MODIFIERS: PopperModifiers = {
-    preventOverflow: { boundariesElement: "viewport" },
+    preventOverflow: { boundariesElement: "viewport" }
 };
 const TRANSITION_DURATION = 100;
 
@@ -40,7 +119,7 @@ class ContextMenu extends AbstractPureComponent<IOverlayLifecycleProps, IContext
         isDarkTheme: false,
         isOpen: false,
         menu: null,
-        offset: null,
+        offset: null
     };
 
     public render() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,30 @@
 # yarn lockfile v1
 
 
+"@blueprintjs/core@^3.0.0", "@blueprintjs/core@^3.1.0", "@blueprintjs/core@^3.4.0", "@blueprintjs/core@^3.6.0":
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/@blueprintjs/core/-/core-3.14.1.tgz#9a0c816bbe6c232d6515361f502506a1fb53acfb"
+  integrity sha512-DlBkztfvk5RgD+MBo22LFxLa7Rz8DVgszNdXF0MY63QGjb1uYwdSJIKXtsN1bn42SRTz24Bzp498VhSJ2+5FuQ==
+  dependencies:
+    "@blueprintjs/icons" "^3.6.0"
+    "@types/dom4" "^2.0.1"
+    classnames "^2.2"
+    dom4 "^2.0.1"
+    normalize.css "^8.0.0"
+    popper.js "^1.14.1"
+    react-popper "^1.0.0"
+    react-transition-group "^2.2.1"
+    resize-observer-polyfill "^1.5.0"
+    tslib "^1.9.0"
+
+"@blueprintjs/icons@^3.6.0":
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/@blueprintjs/icons/-/icons-3.6.0.tgz#af1d2de091d67927ed61671e6967c43620cb416d"
+  integrity sha512-sgB6rJtMjc2mS4aCS+65gK5DCr8fiWgOYi0buc0ODvGD2fwOtOFZuE4Duuj6/GZnCYj4s7E8NZgYK9Krd7G73Q==
+  dependencies:
+    classnames "^2.2"
+    tslib "^1.9.0"
+
 "@types/chai@^4.1.0":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.1.1.tgz#15f1257fab17b7acb9c413f9f88d3d87f834d11e"
@@ -21,6 +45,11 @@
 "@types/dom4@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/dom4/-/dom4-2.0.0.tgz#00dc42fed6b36a7a6dabb8f7a9c9e678ee644e05"
+
+"@types/dom4@^2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@types/dom4/-/dom4-2.0.1.tgz#506d5781b9bcab81bd9a878b198aec7dee2a6033"
+  integrity sha512-kSkVAvWmMZiCYtvqjqQEwOmvKwcH+V4uiv3qPQ8pAh1Xl39xggGEo8gHUqV4waYGHezdFw0rKBR8Jt0CrQSDZA==
 
 "@types/downloadjs@^1.4.0":
   version "1.4.0"


### PR DESCRIPTION
Moves head to 3.6.1 and applies the controlled context menu changes, and then new linting issues in those changes. 